### PR TITLE
Return gRPC call tasks directly

### DIFF
--- a/SnakeRL/Grpc/SnakeEnvClient.cs
+++ b/SnakeRL/Grpc/SnakeEnvClient.cs
@@ -15,13 +15,13 @@ namespace SnakeRL.Grpc
 
         public Task<ResetResponse> ResetAsync()
         {
-            return _client.ResetAsync(new ResetRequest()).ResponseAsync;
+            return _client.ResetAsync(new ResetRequest());
         }
 
         public Task<StepResponse> StepAsync(Action action)
         {
             var request = new StepRequest { Action = action };
-            return _client.StepAsync(request).ResponseAsync;
+            return _client.StepAsync(request);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Simplify `SnakeEnvClient` to return gRPC call tasks directly instead of accessing `ResponseAsync`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when accessing repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf92370c833298bbd68861134950