### PR TITLE
Add start overlay and delayed game start

### DIFF
--- a/SnakeRL/MainWindow.xaml
+++ b/SnakeRL/MainWindow.xaml
@@ -8,6 +8,14 @@
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Background="#222" Height="30">
             <Label x:Name="ScoreLabel" Foreground="White" FontSize="16" Padding="8,0"/>
         </StackPanel>
-        <Canvas Name="GameCanvas" Background="Black"/>
+        <Grid>
+            <Canvas Name="GameCanvas" Background="Black"/>
+            <Grid x:Name="StartOverlay" Background="#AA000000">
+                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="#222" Padding="20" Spacing="10">
+                    <Button x:Name="StartButton" Content="Start" Width="120" Height="40" Click="StartButton_Click"/>
+                    <TextBlock Text="Press Start or any arrow key to begin" Foreground="White" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </Grid>
+        </Grid>
     </DockPanel>
 </Window>

--- a/SnakeRL/MainWindow.xaml.cs
+++ b/SnakeRL/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ namespace SnakeRL
         Game _game = new(GridW, GridH);
         DispatcherTimer _timer = new() { Interval = TimeSpan.FromMilliseconds(120) };
         int _score = 0;
+        bool _gameRunning = false;
 
         public MainWindow()
         {
@@ -23,7 +24,6 @@ namespace SnakeRL
             Height = GridH * Cell + 39 + 30;
 
             _timer.Tick += (_, __) => GameTick();
-            _timer.Start();
             UpdateScore();
             Draw();
         }
@@ -40,6 +40,19 @@ namespace SnakeRL
             }
             UpdateScore();
             Draw();
+        }
+
+        void StartGame()
+        {
+            if (_gameRunning) return;
+            _gameRunning = true;
+            StartOverlay.Visibility = Visibility.Collapsed;
+            _timer.Start();
+        }
+
+        private void StartButton_Click(object sender, RoutedEventArgs e)
+        {
+            StartGame();
         }
 
         void UpdateScore()
@@ -80,15 +93,19 @@ namespace SnakeRL
             {
                 case Key.W:
                 case Key.Up:
+                    StartGame();
                     _game.LastAction = Dir.Up; break;
                 case Key.D:
                 case Key.Right:
+                    StartGame();
                     _game.LastAction = Dir.Right; break;
                 case Key.S:
                 case Key.Down:
+                    StartGame();
                     _game.LastAction = Dir.Down; break;
                 case Key.A:
                 case Key.Left:
+                    StartGame();
                     _game.LastAction = Dir.Left; break;
             }
         }


### PR DESCRIPTION
## Summary
- Add start overlay with button and instructions
- Delay game timer until user initiates play
- Record game running state to prevent premature starts

## Testing
- `dotnet build SnakeRL.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689ce3b9aeac8332b870a12ce0771bf7