### PR TITLE
Wrap start overlay in border for padding

### DIFF
--- a/SnakeRL/MainWindow.xaml
+++ b/SnakeRL/MainWindow.xaml
@@ -11,10 +11,15 @@
         <Grid>
             <Canvas Name="GameCanvas" Background="Black"/>
             <Grid x:Name="StartOverlay" Background="#AA000000">
-                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Background="#222" Padding="20" Spacing="10">
-                    <Button x:Name="StartButton" Content="Start" Width="120" Height="40" Click="StartButton_Click"/>
-                    <TextBlock Text="Press Start or any arrow key to begin" Foreground="White" HorizontalAlignment="Center"/>
-                </StackPanel>
+                <Border HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Background="#222"
+                        Padding="20">
+                    <StackPanel>
+                        <Button x:Name="StartButton" Content="Start" Width="120" Height="40" Click="StartButton_Click" Margin="0 0 0 10"/>
+                        <TextBlock Text="Press Start or any arrow key to begin" Foreground="White" HorizontalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
             </Grid>
         </Grid>
     </DockPanel>


### PR DESCRIPTION
## Summary
- Replace StackPanel with Border and nested StackPanel on start overlay
- Add margin to Start button and remove obsolete Spacing attribute

## Testing
- ⚠️ `dotnet build SnakeRL.sln` *(dotnet not installed)*
- ⚠️ `apt-get update` *(403 repository access error)*

------
https://chatgpt.com/codex/tasks/task_e_689ce5bcc6688332addbedac7c102b9a