### PR TITLE
Handle game over overlay in SnakeRL

### DIFF
--- a/SnakeRL/MainWindow.xaml.cs
+++ b/SnakeRL/MainWindow.xaml.cs
@@ -34,7 +34,9 @@ namespace SnakeRL
             if (reward > 0) _score += (int)reward;
             if (done)
             {
-                MessageBox.Show($"Игра окончена! Очки: {_score}", "SnakeRL");
+                _timer.Stop();
+                _gameRunning = false;
+                StartOverlay.Visibility = Visibility.Visible;
                 _score = 0;
                 _game.Reset();
             }


### PR DESCRIPTION
## Summary
- stop timer and mark game as not running when snake dies
- show start overlay instead of blocking with message box

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_689ce7c1e71483328ddb5ea9bd6885d2