### PR TITLE
Use fully-qualified System.IO.Path for profiles file

### DIFF
--- a/SnakeRL/MainWindow.xaml.cs
+++ b/SnakeRL/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace SnakeRL
         bool _gameRunning = false;
         List<PlayerProfile> _profiles = new();
         PlayerProfile? _currentProfile;
-        string ProfilesPath => Path.Combine(AppContext.BaseDirectory, "players.json");
+        string ProfilesPath => System.IO.Path.Combine(AppContext.BaseDirectory, "players.json");
 
         public MainWindow()
         {


### PR DESCRIPTION
## Summary
- Qualify `ProfilesPath` with `System.IO.Path` to avoid naming conflicts

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ceec1c6e4833283ea8a56133f435f