### PR TITLE
Disable start button until player selected or named

### DIFF
--- a/SnakeRL/MainWindow.xaml
+++ b/SnakeRL/MainWindow.xaml
@@ -16,10 +16,10 @@
                         Background="#222"
                         Padding="20">
                     <StackPanel>
-                        <ComboBox x:Name="PlayerComboBox" Width="120" Margin="0 0 0 10" DisplayMemberPath="Name"/>
-                        <TextBox x:Name="NewPlayerTextBox" Width="120" Margin="0 0 0 10"/>
-                        <Button x:Name="StartButton" Content="Start" Width="120" Height="40" Click="StartButton_Click" Margin="0 0 0 10"/>
-                        <TextBlock Text="Press Start or any arrow key to begin" Foreground="White" HorizontalAlignment="Center"/>
+                        <ComboBox x:Name="PlayerComboBox" Width="120" Margin="0 0 0 10" DisplayMemberPath="Name" SelectionChanged="PlayerComboBox_SelectionChanged"/>
+                        <TextBox x:Name="NewPlayerTextBox" Width="120" Margin="0 0 0 10" TextChanged="NewPlayerTextBox_TextChanged"/>
+                        <Button x:Name="StartButton" Content="Start" Width="120" Height="40" Click="StartButton_Click" Margin="0 0 0 10" IsEnabled="False"/>
+                        <TextBlock Text="Select a player or enter a name to start" Foreground="White" HorizontalAlignment="Center"/>
                     </StackPanel>
                 </Border>
             </Grid>

--- a/SnakeRL/MainWindow.xaml.cs
+++ b/SnakeRL/MainWindow.xaml.cs
@@ -51,6 +51,7 @@ namespace SnakeRL
             }
             PlayerComboBox.ItemsSource = _profiles;
             if (_profiles.Count > 0) PlayerComboBox.SelectedIndex = 0;
+            UpdateStartButtonState();
         }
 
         void SaveProfiles()
@@ -113,6 +114,8 @@ namespace SnakeRL
                 SaveProfiles();
             }
 
+            UpdateStartButtonState();
+
             _gameRunning = true;
             StartOverlay.Visibility = Visibility.Collapsed;
             _timer.Start();
@@ -121,6 +124,22 @@ namespace SnakeRL
         private void StartButton_Click(object sender, RoutedEventArgs e)
         {
             StartGame();
+        }
+
+        private void PlayerComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateStartButtonState();
+        }
+
+        private void NewPlayerTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            UpdateStartButtonState();
+        }
+
+        void UpdateStartButtonState()
+        {
+            StartButton.IsEnabled = PlayerComboBox.SelectedItem != null ||
+                                   !string.IsNullOrWhiteSpace(NewPlayerTextBox.Text);
         }
 
         void UpdateScore()


### PR DESCRIPTION
## Summary
- Disable the start button until a player is chosen or a new name is entered and show an instructional message on the overlay.
- Implement `UpdateStartButtonState` to toggle the start button based on player selection or text input and hook it into relevant events.

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `dotnet build SnakeRL.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689cf19b722c8332be4ea8f6596795ca