### PR TITLE
Avoid key presses when start overlay visible

### DIFF
--- a/SnakeRL/MainWindow.xaml.cs
+++ b/SnakeRL/MainWindow.xaml.cs
@@ -157,6 +157,9 @@ namespace SnakeRL
 
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
+            if (StartOverlay.Visibility == Visibility.Visible)
+                return;  // allow typing without triggering game controls
+
             switch (e.Key)
             {
                 case Key.W:


### PR DESCRIPTION
## Summary
- Ignore window key events while the start overlay is visible to allow text entry without starting or controlling the game

## Testing
- `dotnet build` *(fails: /usr/bin/dotnet: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cf19c69e883328f4c82fffc68346c