### PR TITLE
Improve start overlay and keyboard handling

### DIFF
--- a/SnakeRL/MainWindow.xaml
+++ b/SnakeRL/MainWindow.xaml
@@ -18,8 +18,9 @@
                     <StackPanel>
                         <ComboBox x:Name="PlayerComboBox" Width="120" Margin="0 0 0 10" DisplayMemberPath="Name" SelectionChanged="PlayerComboBox_SelectionChanged"/>
                         <TextBox x:Name="NewPlayerTextBox" Width="120" Margin="0 0 0 10" TextChanged="NewPlayerTextBox_TextChanged"/>
-                        <Button x:Name="StartButton" Content="Start" Width="120" Height="40" Click="StartButton_Click" Margin="0 0 0 10" IsEnabled="False"/>
-                        <TextBlock Text="Select a player or enter a name to start" Foreground="White" HorizontalAlignment="Center"/>
+                        <Button x:Name="StartButton" Content="Start" Width="120" Height="40" Click="StartButton_Click" Margin="0 0 0 10" IsEnabled="False" Visibility="Collapsed"/>
+                        <TextBlock x:Name="NamePromptText" Text="Введите имя или выберите игрока" Foreground="White" HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="StartHintText" Text="Нажмите AWSD или стрелки для старта, либо кнопку Старт" Foreground="White" HorizontalAlignment="Center" Visibility="Collapsed"/>
                     </StackPanel>
                 </Border>
             </Grid>

--- a/SnakeRL/MainWindow.xaml.cs
+++ b/SnakeRL/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ namespace SnakeRL
         bool _gameRunning = false;
         List<PlayerProfile> _profiles = new();
         PlayerProfile? _currentProfile;
+        bool _playerSelected;
         string ProfilesPath => System.IO.Path.Combine(AppContext.BaseDirectory, "players.json");
 
         public MainWindow()
@@ -73,6 +74,12 @@ namespace SnakeRL
                 _timer.Stop();
                 _gameRunning = false;
                 StartOverlay.Visibility = Visibility.Visible;
+                PlayerComboBox.Visibility = Visibility.Collapsed;
+                NewPlayerTextBox.Visibility = Visibility.Collapsed;
+                NamePromptText.Visibility = Visibility.Collapsed;
+                StartButton.Visibility = Visibility.Visible;
+                StartHintText.Visibility = Visibility.Visible;
+                StartButton.IsEnabled = true;
                 if (_currentProfile != null)
                 {
                     if (_game.Snake.Count > _currentProfile.BestLength)
@@ -110,6 +117,16 @@ namespace SnakeRL
 
             if (_currentProfile != null)
             {
+                if (!_playerSelected)
+                {
+                    _playerSelected = true;
+                    PlayerComboBox.Visibility = Visibility.Collapsed;
+                    NewPlayerTextBox.Visibility = Visibility.Collapsed;
+                    NamePromptText.Visibility = Visibility.Collapsed;
+                    StartButton.Visibility = Visibility.Visible;
+                    StartHintText.Visibility = Visibility.Visible;
+                }
+
                 _currentProfile.GamesPlayed++;
                 SaveProfiles();
             }
@@ -176,27 +193,23 @@ namespace SnakeRL
 
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
-            if (StartOverlay.Visibility == Visibility.Visible)
+            bool overlayVisible = StartOverlay.Visibility == Visibility.Visible;
+            if (overlayVisible && !StartButton.IsEnabled)
                 return;  // allow typing without triggering game controls
 
-            switch (e.Key)
+            Dir? action = e.Key switch
             {
-                case Key.W:
-                case Key.Up:
-                    StartGame();
-                    _game.LastAction = Dir.Up; break;
-                case Key.D:
-                case Key.Right:
-                    StartGame();
-                    _game.LastAction = Dir.Right; break;
-                case Key.S:
-                case Key.Down:
-                    StartGame();
-                    _game.LastAction = Dir.Down; break;
-                case Key.A:
-                case Key.Left:
-                    StartGame();
-                    _game.LastAction = Dir.Left; break;
+                Key.W or Key.Up => Dir.Up,
+                Key.D or Key.Right => Dir.Right,
+                Key.S or Key.Down => Dir.Down,
+                Key.A or Key.Left => Dir.Left,
+                _ => null
+            };
+
+            if (action != null)
+            {
+                StartGame();
+                _game.LastAction = action.Value;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Hide start button until a player is chosen and display new prompts for name entry and start instructions.
- Track initial player selection and retain it across restarts, showing only start controls after game over.
- Prevent arrow/WASD keys from starting the game until a name is selected.

## Testing
- `dotnet build SnakeRL.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cf78d1f2c833282792db6f7a3b78b